### PR TITLE
added support for references

### DIFF
--- a/assets/style.sass
+++ b/assets/style.sass
@@ -49,6 +49,13 @@ svg
   top: 0
   width: 4pc
 
+.right
+  float: right
+
+blockquote
+  background-color: #eee
+  padding: 3px
+
 h1
   font-weight: $light-weight
   font-size: 3 * $type-height

--- a/assets/template.pug
+++ b/assets/template.pug
@@ -136,3 +136,12 @@ body
           span.school #{level.institution}
           | &nbsp;
           span.time #{level.startDate.split('-')[0]}&hairsp;&ndash;&hairsp;#{level.endDate.split('-')[0]}
+
+  if references && references.length
+    section.category
+      h2 References
+
+      each ref in references
+        blockquote #{ref.reference}
+        b.right - #{ref.name}
+        | &nbsp;


### PR DESCRIPTION
Each reference has two properties, 'reference' and 'name'. This pulls each reference out into a block quote (lightly styled) and then sticks the name into a bold, right-aligned line below it.