### PR TITLE
Proposal: allow publications to be rendered as conference talks

### DIFF
--- a/assets/style.sass
+++ b/assets/style.sass
@@ -117,3 +117,12 @@ section
     color: inherit
     font-style: italic
     font-weight: $regular-weight
+
+.talk
+  margin-bottom: $grid-height
+
+.talk-name
+  font-weight: $semibold-weight
+
+.presentations
+  margin: 0

--- a/assets/template.pug
+++ b/assets/template.pug
@@ -136,3 +136,28 @@ body
           span.school #{level.institution}
           | &nbsp;
           span.time #{level.startDate.split('-')[0]}&hairsp;&ndash;&hairsp;#{level.endDate.split('-')[0]}
+
+  if publications && publications.length
+    section.category
+      - var talksObj = publications.reduce((obj, publication) => {
+      -   obj[publication.name] = (obj[publication.name] || []).concat(publication)
+      -   return obj
+      - }, {})
+
+      h2 Conference talks
+
+      ul.talks
+        each presentations, talk in talksObj
+          li.talk
+            .talk-name #{talk}
+            ul.presentations
+              each presentation in presentations
+                li.presentation
+                  span.presentation-name
+                    | #{presentation.publisher},&nbsp;
+                  span.presentation-date
+                    | #{presentation.releaseDate}
+                  if presentation.website
+                    span.presentation-video
+                      | &nbsp;
+                      +link(presentation.website)


### PR DESCRIPTION
### Why
It would be nice to be able to share the talks we've given on our resumes, to showcase our expertise and experience.

### How to test
- Get a resume with some publications included. You can get mine by running
 `curl https://juan-caicedo-resume-cson.now.sh > test-resume.cson`
- Generate a new resume by running 
  `cobbler -i test-resume.cson -o test-output.pdf && open test-output.pdf`
- Scroll to the bottom and look at the conference section

I'll comment in the code areas where I would like specific feedback, though any is appreciated 😄