### PR TITLE
Update resume schema

### DIFF
--- a/lib/cobbler.js
+++ b/lib/cobbler.js
@@ -9,8 +9,7 @@ var nightmare = require('nightmare')
 var path = require('path')
 var traverse = require('traverse')
 var url = require('url')
-var validator = require('z-schema')
-var RESUME_SCHEMA = require('resume-schema/schema.json')
+var resumeSchema = require('resume-schema')
 
 module.exports = {
   //
@@ -47,8 +46,13 @@ module.exports = {
         }
       })
       .then(data => {
-        return validator.validate(data, RESUME_SCHEMA)
-          .then(_ => data)
+        return new Promise((resolve, reject) => {
+          resumeSchema.validate(data, (err, report) => {
+            if (err) return reject(err, report)
+
+            resolve(data)
+          })
+        })
       })
       .then(data => {
         debug('cobbler:load')('Data: %j', data)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "moment": "~2.17.0",
     "nightmare": "~2.8.1",
     "pug": "^2.0.4",
-    "resume-schema": "0.0.16",
+    "resume-schema": "0.0.18",
     "temp": "~0.8.3",
     "traverse": "~0.6.6"
   }


### PR DESCRIPTION
This PR updates resume-schema (so it doesn't balk at my meta key in my resume) and uses the schema package's provided `validate` method for schema validation.