### PR TITLE
Add Source Sans 3 to font

### DIFF
--- a/assets/style.sass
+++ b/assets/style.sass
@@ -19,7 +19,7 @@ html
 
 body
   color $black
-  font: $type-height 'Source Sans Pro'
+  font: $type-height 'Source Sans Pro', 'Source Sans 3'
   font-weight: $regular-weight
   line-height: $grid-height
   margin: 10pc 0 0 0


### PR DESCRIPTION
The instructions in mi5 specify an Adobe open source font repo. They
have changed the name of the published font to "Source Sans 3", this
change will be backwards compatible for anyone who has the old font
installed.