### PR TITLE
support multiple start and end

### DIFF
--- a/assets/template.pug
+++ b/assets/template.pug
@@ -4,10 +4,9 @@ mixin link(url)
     a(href=url.href)= url.host || url.href || url
     | )
 
-mixin duration(start, end)
-  - var mStart = moment(start)
-  - var mEnd = moment(end)
-  - var mDuration = moment.duration(mEnd.diff(mStart))
+
+mixin shortTime(details)
+  - var mDuration = timeHelpers.calculateDuration(details)
 
   if mDuration.asYears() >= 2
     if mDuration.months() < 2 || mDuration.months() > 10
@@ -18,6 +17,15 @@ mixin duration(start, end)
     | #{Math.round(mDuration.asMonths())} months
   else
     | #{mDuration.humanize()}
+
+mixin longTime(startDate, endDate)
+  =startDate.split('-')[0]
+  | &hairsp;&ndash;&hairsp;
+  if endDate
+    =endDate.split('-')[0]
+  else
+    | Present
+    
 
 mixin gig(details, short)
   .company
@@ -31,14 +39,19 @@ mixin gig(details, short)
   if details.startDate
     .time
       if short
-        +duration(details.startDate, details.endDate)
+        +shortTime(details)
       else
-        =details.startDate.split('-')[0]
-        | &hairsp;&ndash;&hairsp;
-        if details.endDate
-          =details.endDate.split('-')[0]
-        else
-          | Present
+        +longTime(details.startDate, details.endDate)
+  if details.dates && !details.startDate
+    .time
+      if short
+        +shortTime(details)
+      else
+        each entry, i in details.dates
+          +longTime(entry.startDate, entry.endDate)
+          if i != details.dates.length - 1
+            | and
+
   if details.summary
     p!= details.summary
   if details.highlights

--- a/lib/cobbler.js
+++ b/lib/cobbler.js
@@ -10,6 +10,7 @@ var path = require('path')
 var traverse = require('traverse')
 var url = require('url')
 var resumeSchema = require('resume-schema')
+var timeHelpers = require("./time_helpers")
 
 module.exports = {
   //
@@ -115,6 +116,7 @@ module.exports = {
         basedir: path.resolve(__dirname, '../assets'),
       })(Object.assign(data, {
         moment: moment,
+        timeHelpers: timeHelpers
       })))
       .then(output => new Promise((resolve, reject) => {
         debug('cobbler:render')('Render output: %s', output)

--- a/lib/time_helpers.js
+++ b/lib/time_helpers.js
@@ -1,0 +1,17 @@
+var moment = require("moment");
+
+const calculateDuration = (details) => {
+  const dateSpans = details.dates || [
+    {
+      startDate: details.startDate,
+      endDate: details.endDate,
+    },
+  ];
+
+  return dateSpans.reduce(
+    (dur, { startDate, endDate }) =>
+      dur.add(moment.duration(moment(endDate).diff(moment(startDate)))),
+    moment.duration(0)
+  );
+};
+module.exports = { calculateDuration };

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,11 +186,6 @@
         "inherits": "~2.0.0"
       }
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1102,6 +1097,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -1860,11 +1865,11 @@
       }
     },
     "resume-schema": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/resume-schema/-/resume-schema-0.0.16.tgz",
-      "integrity": "sha1-Q68zT3l86Uy07JgM4RztHzO7z+s=",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/resume-schema/-/resume-schema-0.0.18.tgz",
+      "integrity": "sha512-CNomhyZSKzrpUqYCFiRRPpfClz78BhgOb+ksGxLy46Yt/xBwnZP/2bLJO60GbAMnI1nxMCtSj+pjBQtILvPs6w==",
       "requires": {
-        "z-schema": "~2.4.8"
+        "z-schema": "~3.19.0"
       }
     },
     "right-align": {
@@ -2320,6 +2325,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validator": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -2458,12 +2468,22 @@
       }
     },
     "z-schema": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-2.4.10.tgz",
-      "integrity": "sha1-HvH0Qzp6dz7kzVSUvxrzCzGDZus=",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.19.1.tgz",
+      "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
       "requires": {
-        "bluebird": ">=2.2.2",
-        "request": ">=2.39.0"
+        "commander": "^2.7.1",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^9.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "optional": true
+        }
       }
     }
   }


### PR DESCRIPTION
For situations where you go back to the same client again after a break, it would be nice to be able to reuse the same "project" block to save space, but have the duration reflect the sum of the time you worked there.

Allows you to put this block under a project or employer 
```
    dates: [
      {
        startDate: "2022-02-01"
        endDate: "2022-05-24"
      },
      {
        startDate: "2020-07-28"
        endDate: "2020-10-16"
      }
    ]
```

Side note, I was not able to get nightmare to actually generate the pdf locally, and since I'm out of the office, I didn't want to spend my time off debugging, but i'm pretty sure it's just the setup of my machine, since it generates the HTML and I didn't touch any of the pdf generation stuff. But id' appreciate whoever looks at this confirming it works on their machine.